### PR TITLE
(Custom/DLC) "Split on any world transition" to not split on Nexus / DLC Hub

### DIFF
--- a/LiveSplit.TheTalosPrinciple.asl
+++ b/LiveSplit.TheTalosPrinciple.asl
@@ -29,7 +29,7 @@ startup {
   settings.Add("Split when exiting Floor 5", false);
   settings.Add("Start the run in any world", false);
   settings.Add("(Custom/DLC) Split when solving any arranger", false);
-  settings.Add("(Custom/DLC) Split on any world transition", false);
+  settings.Add("(Custom/DLC) Split on any world transition (except Nexus/Hub)", false);
 
   settings.Add("worldsplits", true, "Don't split on sigil collections in these worlds:");
   settings.CurrentDefaultParent = "worldsplits";
@@ -418,15 +418,17 @@ split {
       vars.log("Restarted checkpoint in world " + mapName);
       return false; // Ensure 'restart checkpoint' doesn't trigger map change
     }
-    if (settings["Split on return to Nexus or DLC Hub"] &&
-      (mapName.EndsWith("Nexus.wld") ||
-       mapName.EndsWith("DLC_01_Hub.wld"))) {
-      vars.log("Returned to Nexus/Hub from " + vars.currentWorld);
-      return true;
-    }
-    if (settings["(Custom/DLC) Split on any world transition"]) {
-      vars.log("Initial load for world change from " + mapName + " to " + vars.currentWorld);
-      return true;
+
+    if (mapName.EndsWith("Nexus.wld") || mapName.EndsWith("DLC_01_Hub.wld")) {
+      if (settings["Split on return to Nexus or DLC Hub"]) {
+        vars.log("Returned to Nexus/Hub from " + vars.currentWorld);
+        return true;
+      }
+    } else {
+      if (settings["(Custom/DLC) Split on any world transition (except Nexus/Hub)"]) {
+        vars.log("Initial load for world change from " + mapName + " to " + vars.currentWorld);
+        return true;
+      }
     }
   }
 

--- a/LiveSplit.TheTalosPrinciple.asl
+++ b/LiveSplit.TheTalosPrinciple.asl
@@ -29,7 +29,7 @@ startup {
   settings.Add("Split when exiting Floor 5", false);
   settings.Add("Start the run in any world", false);
   settings.Add("(Custom/DLC) Split when solving any arranger", false);
-  settings.Add("(Custom/DLC) Split on any world transition (except Nexus/Hub)", false);
+  settings.Add("(Custom/DLC) Split on any world transition other than Nexus/Hub", false);
 
   settings.Add("worldsplits", true, "Don't split on sigil collections in these worlds:");
   settings.CurrentDefaultParent = "worldsplits";
@@ -425,7 +425,7 @@ split {
         return true;
       }
     } else {
-      if (settings["(Custom/DLC) Split on any world transition (except Nexus/Hub)"]) {
+      if (settings["(Custom/DLC) Split on any world transition other than Nexus/Hub"]) {
         vars.log("Initial load for world change from " + mapName + " to " + vars.currentWorld);
         return true;
       }

--- a/LiveSplit.TheTalosPrinciple.asl
+++ b/LiveSplit.TheTalosPrinciple.asl
@@ -11,6 +11,7 @@ startup {
   // Commonly used, defaults to true
   settings.Add("Don't start the run if cheats are active", true);
   settings.Add("Split on return to Nexus or DLC Hub", true);
+  settings.Add("Split on any world transition other than Nexus/Hub", false);
   settings.Add("Split on item unlocks", true);
   settings.Add("Split on star collection in the Nexus", true);
 
@@ -29,7 +30,6 @@ startup {
   settings.Add("Split when exiting Floor 5", false);
   settings.Add("Start the run in any world", false);
   settings.Add("(Custom/DLC) Split when solving any arranger", false);
-  settings.Add("(Custom/DLC) Split on any world transition other than Nexus/Hub", false);
 
   settings.Add("worldsplits", true, "Don't split on sigil collections in these worlds:");
   settings.CurrentDefaultParent = "worldsplits";
@@ -425,7 +425,7 @@ split {
         return true;
       }
     } else {
-      if (settings["(Custom/DLC) Split on any world transition other than Nexus/Hub"]) {
+      if (settings["Split on any world transition other than Nexus/Hub"]) {
         vars.log("Initial load for world change from " + mapName + " to " + vars.currentWorld);
         return true;
       }


### PR DESCRIPTION
- Renamed to `(Custom/DLC) Split on any world transition (except Nexus/Hub)`
- This makes this splitting option a complementary of `Split on return to Nexus or DLC Hub` (select both for the same old behavior of splitting on any World Transition)